### PR TITLE
Fix the build with parallel make and slibtool.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -52,7 +52,7 @@ LT_RELEASE  = @LT_RELEASE@
 LT_REVISION = @LT_REVISION@
 LT_LDFLAGS  = -no-undefined -rpath $(libdir) -release $(LT_RELEASE) -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
-all: $(srcdir)/configure Makefile $(objects) $(objects)/$(TARGET) $(objects)/$(SDLMAIN_TARGET)
+all: $(srcdir)/configure Makefile $(objects)/$(TARGET) $(objects)/$(SDLMAIN_TARGET)
 
 $(srcdir)/configure: $(srcdir)/configure.ac
 	@echo "Warning, configure is out of date, please re-run autogen.sh"
@@ -60,8 +60,9 @@ $(srcdir)/configure: $(srcdir)/configure.ac
 Makefile: $(srcdir)/Makefile.in
 	$(SHELL) config.status $@
 
-$(objects):
-	$(SHELL) $(auxdir)/mkinstalldirs $@
+$(objects)/.created:
+	$(SHELL) $(auxdir)/mkinstalldirs $(objects)
+	touch $@
 
 .PHONY: all depend install install-bin install-hdrs install-lib install-data install-man uninstall uninstall-bin uninstall-hdrs uninstall-lib uninstall-data uninstall-man clean distclean dist
 depend:
@@ -69,6 +70,8 @@ depend:
 	$(SHELL) $(auxdir)/makedep.sh
 
 include $(depend)
+
+$(OBJECTS) $(SDLMAIN_OBJECTS): $(objects)/.created
 
 $(objects)/$(TARGET): $(OBJECTS)
 	$(LIBTOOL) --mode=link $(CC) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS)
@@ -87,7 +90,7 @@ install-hdrs:
 	    $(INSTALL) -m 644 $(srcdir)/include/$$file $(DESTDIR)$(includedir)/SDL/$$file; \
 	done
 	$(INSTALL) -m 644 include/SDL_config.h $(DESTDIR)$(includedir)/SDL/SDL_config.h
-install-lib: $(objects) $(objects)/$(TARGET) $(objects)/$(SDLMAIN_TARGET)
+install-lib: $(objects)/$(TARGET) $(objects)/$(SDLMAIN_TARGET)
 	$(SHELL) $(auxdir)/mkinstalldirs $(DESTDIR)$(libdir)
 	$(LIBTOOL) --mode=install $(INSTALL) $(objects)/$(TARGET) $(DESTDIR)$(libdir)/$(TARGET)
 	$(LIBTOOL) --mode=install $(INSTALL) $(objects)/$(SDLMAIN_TARGET) $(DESTDIR)$(libdir)/$(SDLMAIN_TARGET)


### PR DESCRIPTION
The mkinstalldirs script if often slower than slibtool resulting in build failures when the 'build' directory does not yet exist.

See:

https://github.com/libsdl-org/SDL/commit/39e8e3951cff8a6f6c284c1dcd0e3e5d66438f81
https://github.com/libsdl-org/SDL_mixer/commit/b432a23ac02ef83e9114f70e81738b30c0853cf9