### PR TITLE
Comma-separated lists in audio/video driver environment variables

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -180,18 +180,22 @@ int SDL_VideoInit (const char *driver_name, Uint32 flags)
 	index = 0;
 	video = NULL;
 	if ( driver_name != NULL ) {
-#if 0	/* This will be replaced with a better driver selection API */
-		if ( SDL_strrchr(driver_name, ':') != NULL ) {
-			index = atoi(SDL_strrchr(driver_name, ':')+1);
-		}
-#endif
-		for ( i=0; bootstrap[i]; ++i ) {
-			if ( SDL_strcasecmp(bootstrap[i]->name, driver_name) == 0) {
-				if ( bootstrap[i]->available() ) {
-					video = bootstrap[i]->create(index);
-					break;
+		const char *driver_attempt = driver_name;
+		while(driver_attempt != NULL && *driver_attempt != 0 && video == NULL) {
+			const char* driver_attempt_end = SDL_strchr(driver_attempt, ',');
+			size_t driver_attempt_len = (driver_attempt_end != NULL) ? (driver_attempt_end - driver_attempt)
+			                                                         : SDL_strlen(driver_attempt);
+
+			for ( i=0; bootstrap[i]; ++i ) {
+				if ((driver_attempt_len == SDL_strlen(bootstrap[i]->name)) &&
+				    (SDL_strncasecmp(bootstrap[i]->name, driver_attempt, driver_attempt_len) == 0)) {
+					if ( bootstrap[i]->available() ) {
+						video = bootstrap[i]->create(index);
+						break;
+					}
 				}
 			}
+			driver_attempt = (driver_attempt_end != NULL) ? (driver_attempt_end + 1) : NULL;
 		}
 	} else {
 		for ( i=0; bootstrap[i]; ++i ) {


### PR DESCRIPTION
Adapted from SDL2:
     https://github.com/libsdl-org/SDL/pull/4267
     https://github.com/libsdl-org/SDL/pull/4618

This is super helpful for instance when setting `SDL_VIDEODRIVER` globally to prefer Wayland. Since both SDL1 and SDL2 share the variable name and there's no `wayland` driver in SDL1, it fails to initialize video subsystem, while with this change it can nicely fallback to `x11`.