### PR TITLE
Include SDL_iconv.obj in OS/2 builds

### DIFF
--- a/Makefile.os2
+++ b/Makefile.os2
@@ -71,8 +71,7 @@ videoobjs = SDL_blit.obj SDL_blit_0.obj SDL_blit_1.obj SDL_blit_A.obj &
             SDL_os2fslib.obj &
             SDL_nullevents.obj SDL_nullmouse.obj SDL_nullvideo.obj
 
-stdlibobjs = SDL_malloc.obj SDL_qsort.obj SDL_string.obj
-# SDL_iconv.obj
+stdlibobjs = SDL_iconv.obj SDL_malloc.obj SDL_qsort.obj SDL_string.obj
 
 !ifeq HERMES 1
 hermesobjs= mmx_main.obj mmxp2_32.obj x86_main.obj x86p_16.obj x86p_32.obj

--- a/test/Makefile.os2
+++ b/test/Makefile.os2
@@ -1,11 +1,10 @@
 TARGETS = checkkeys.exe graywin.exe loopwave.exe testalpha.exe testbitmap.exe &
           testblitspeed.exe testcdrom.exe testcursor.exe testdyngl.exe &
           testerror.exe testfile.exe testgamma.exe testgl.exe testhread.exe &
-          testjoystick.exe testkeys.exe testlock.exe &
+          testiconv.exe testjoystick.exe testkeys.exe testlock.exe &
           testoverlay2.exe testoverlay.exe testpalette.exe testplatform.exe &
           testsem.exe testsprite.exe testtimer.exe testver.exe testvidinfo.exe &
           testwin.exe testwm.exe threadwin.exe torturethread.exe testloadso.exe
-# testiconv.exe
 
 OBJS = $(TARGETS:.exe=.obj)
 


### PR DESCRIPTION
This has only been compile tested.