### PR TITLE
Use correct macros for Darwin PPC

### DIFF
--- a/src/video/quartz/SDL_QuartzGL.m
+++ b/src/video/quartz/SDL_QuartzGL.m
@@ -41,7 +41,7 @@
 #define NSOpenGLPFASamples ((NSOpenGLPixelFormatAttribute) 56)
 #endif
 
-#ifdef __powerpc__   /* we lost this in 10.6, which has no PPC support. */
+#ifdef __POWERPC__   /* we lost this in 10.7, which has no PPC support. */
 @implementation NSOpenGLContext (CGLContextAccess)
 - (CGLContextObj) cglContext;
 {

--- a/src/video/quartz/SDL_QuartzVideo.h
+++ b/src/video/quartz/SDL_QuartzVideo.h
@@ -68,7 +68,7 @@
 #include "../../events/SDL_events_c.h"
 
 
-#ifdef __powerpc__
+#ifdef __POWERPC__
 /* 
     This is a workaround to directly access NSOpenGLContext's CGL context
     We need this to check for errors NSOpenGLContext doesn't support

--- a/src/video/quartz/SDL_QuartzVideo.m
+++ b/src/video/quartz/SDL_QuartzVideo.m
@@ -586,7 +586,7 @@ static void QZ_UnsetVideoMode (_THIS, BOOL to_desktop, BOOL save_gl)
                 QZ_TearDownOpenGL (this);
             }
 
-            #ifdef __powerpc__  /* we only use this for pre-10.3 compatibility. */
+            #ifdef __ppc__  /* we only use this for pre-10.3 compatibility. */
             CGLSetFullScreen (NULL);
             #endif
         }


### PR DESCRIPTION
In few places wrong macros are used for Darwin PPC (it follows from code comments that MacOS is meant in those instances). There is no `__powerpc__` on Darwin.

Three definitions are there:
`__ppc__` = ppc32
`__ppc64__` = ppc64
`__POWERPC__` = ppc32/ppc64

See, for example: https://opensource.apple.com/source/gcc/gcc-5465/gcc/config/rs6000/darwin.h.auto.html
(Also, 10.6 does support ppc32.)