### PR TITLE
atari: handle shift state properly in gem

### DIFF
--- a/src/video/ataricommon/SDL_atarievents_c.h
+++ b/src/video/ataricommon/SDL_atarievents_c.h
@@ -49,6 +49,6 @@ extern void SDL_AtariMint_BackgroundTasks(void);
 /* Atari to Unicode charset translation table */
 extern Uint16 SDL_AtariToUnicodeTable[256];
 SDL_keysym *SDL_Atari_TranslateKey(int scancode, SDL_keysym *keysym,
-	SDL_bool pressed);
+	SDL_bool pressed, short kstate);
 
 #endif /* _SDL_ATARI_EVENTS_H_ */

--- a/src/video/ataricommon/SDL_atarikeys.h
+++ b/src/video/ataricommon/SDL_atarikeys.h
@@ -148,4 +148,10 @@
 #define SCANCODE_RIGHT		0x4d
 #define SCANCODE_LEFT		0x4b
 
+/* some keys give different scancode with CTRL */
+#define SCANCODE_CNTL_HOME	0x77
+#define SCANCODE_SHFT_HOME	0x4f
+#define SCANCODE_CNTL_LEFT	0x73
+#define SCANCODE_CNTL_RIGHT	0x74
+
 #endif /* _SDL_ATARIKEYS_H_ */

--- a/src/video/ataricommon/SDL_biosevents.c
+++ b/src/video/ataricommon/SDL_biosevents.c
@@ -70,6 +70,7 @@ void AtariBios_PumpEvents(_THIS)
 {
 	int i;
 	SDL_keysym keysym;
+	short kstate;
 
 	SDL_AtariMint_BackgroundTasks();
 
@@ -83,19 +84,20 @@ void AtariBios_PumpEvents(_THIS)
 	}
 
 	/* Read special keys */
-	UpdateSpecialKeys(Kbshift(-1));
+	kstate = Kbshift(-1);
+	UpdateSpecialKeys(kstate);
 
 	/* Now generate events */
 	for (i=0; i<ATARIBIOS_MAXKEYS; i++) {
 		/* Key pressed ? */
 		if (bios_currentkeyboard[i] && !bios_previouskeyboard[i])
 			SDL_PrivateKeyboard(SDL_PRESSED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_TRUE));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_TRUE, kstate));
 			
 		/* Key unpressed ? */
 		if (bios_previouskeyboard[i] && !bios_currentkeyboard[i])
 			SDL_PrivateKeyboard(SDL_RELEASED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, 0));
 	}
 
 	if (use_dev_mouse) {

--- a/src/video/ataricommon/SDL_gemdosevents.c
+++ b/src/video/ataricommon/SDL_gemdosevents.c
@@ -71,6 +71,7 @@ void AtariGemdos_PumpEvents(_THIS)
 {
 	int i;
 	SDL_keysym keysym;
+	short kstate;
 
 	SDL_AtariMint_BackgroundTasks();
 
@@ -84,19 +85,20 @@ void AtariGemdos_PumpEvents(_THIS)
 	}
 
 	/* Read special keys */
-	UpdateSpecialKeys(Kbshift(-1));
+	kstate = Kbshift(-1);
+	UpdateSpecialKeys(kstate);
 
 	/* Now generate events */
 	for (i=0; i<ATARIBIOS_MAXKEYS; i++) {
 		/* Key pressed ? */
 		if (gemdos_currentkeyboard[i] && !gemdos_previouskeyboard[i])
 			SDL_PrivateKeyboard(SDL_PRESSED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_TRUE));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_TRUE, kstate));
 			
 		/* Key unpressed ? */
 		if (gemdos_previouskeyboard[i] && !gemdos_currentkeyboard[i])
 			SDL_PrivateKeyboard(SDL_RELEASED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, 0));
 	}
 
 	if (use_dev_mouse) {

--- a/src/video/ataricommon/SDL_ikbdevents.c
+++ b/src/video/ataricommon/SDL_ikbdevents.c
@@ -43,6 +43,21 @@
 
 static Uint16 atari_prevmouseb;	/* save state of mouse buttons */
 
+static short AtariIkbd_Shiftstate(void)
+{
+	short kstate = 0;
+
+	if (SDL_AtariIkbd_keyboard[SCANCODE_LEFTSHIFT] == KEY_PRESSED)
+		kstate |= K_LSHIFT;
+	if (SDL_AtariIkbd_keyboard[SCANCODE_RIGHTSHIFT] == KEY_PRESSED)
+		kstate |= K_RSHIFT;
+	if (SDL_AtariIkbd_keyboard[SCANCODE_LEFTCONTROL] == KEY_PRESSED)
+		kstate |= K_CTRL;
+	if (SDL_AtariIkbd_keyboard[SCANCODE_LEFTALT] == KEY_PRESSED)
+		kstate |= K_ALT;
+	return kstate;
+}
+
 void AtariIkbd_InitOSKeymap(_THIS)
 {
 	SDL_memset((void *) SDL_AtariIkbd_keyboard, KEY_UNDEFINED, sizeof(SDL_AtariIkbd_keyboard));
@@ -82,14 +97,14 @@ void AtariIkbd_PumpEvents(_THIS)
 		/* Key pressed ? */
 		if (SDL_AtariIkbd_keyboard[i]==KEY_PRESSED) {
 			SDL_PrivateKeyboard(SDL_PRESSED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_TRUE));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_TRUE, AtariIkbd_Shiftstate()));
 			SDL_AtariIkbd_keyboard[i]=KEY_UNDEFINED;
 		}
 			
 		/* Key released ? */
 		if (SDL_AtariIkbd_keyboard[i]==KEY_RELEASED) {
 			SDL_PrivateKeyboard(SDL_RELEASED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, 0));
 			SDL_AtariIkbd_keyboard[i]=KEY_UNDEFINED;
 		}
 	}

--- a/src/video/gem/SDL_gemevents.c
+++ b/src/video/gem/SDL_gemevents.c
@@ -160,12 +160,12 @@ void GEM_PumpEvents(_THIS)
 		/* Key pressed ? */
 		if (gem_currentkeyboard[i] && !gem_previouskeyboard[i])
 			SDL_PrivateKeyboard(SDL_PRESSED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_TRUE));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_TRUE, kstate));
 
 		/* Key unpressed ? */
 		if (gem_previouskeyboard[i] && !gem_currentkeyboard[i])
 			SDL_PrivateKeyboard(SDL_RELEASED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, 0));
 	}
 
 	SDL_memcpy(gem_previouskeyboard,gem_currentkeyboard,sizeof(gem_previouskeyboard));


### PR DESCRIPTION
Currently the state of the SHIFT key(s) has not been handled at all.

Contributed by @th-otto.