### PR TITLE
atari: handle also shift released state

### DIFF
--- a/src/video/ataricommon/SDL_biosevents.c
+++ b/src/video/ataricommon/SDL_biosevents.c
@@ -97,7 +97,7 @@ void AtariBios_PumpEvents(_THIS)
 		/* Key unpressed ? */
 		if (bios_previouskeyboard[i] && !bios_currentkeyboard[i])
 			SDL_PrivateKeyboard(SDL_RELEASED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, 0));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, kstate));
 	}
 
 	if (use_dev_mouse) {

--- a/src/video/ataricommon/SDL_gemdosevents.c
+++ b/src/video/ataricommon/SDL_gemdosevents.c
@@ -98,7 +98,7 @@ void AtariGemdos_PumpEvents(_THIS)
 		/* Key unpressed ? */
 		if (gemdos_previouskeyboard[i] && !gemdos_currentkeyboard[i])
 			SDL_PrivateKeyboard(SDL_RELEASED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, 0));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, kstate));
 	}
 
 	if (use_dev_mouse) {

--- a/src/video/ataricommon/SDL_ikbdevents.c
+++ b/src/video/ataricommon/SDL_ikbdevents.c
@@ -104,7 +104,7 @@ void AtariIkbd_PumpEvents(_THIS)
 		/* Key released ? */
 		if (SDL_AtariIkbd_keyboard[i]==KEY_RELEASED) {
 			SDL_PrivateKeyboard(SDL_RELEASED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, 0));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, AtariIkbd_Shiftstate()));
 			SDL_AtariIkbd_keyboard[i]=KEY_UNDEFINED;
 		}
 	}

--- a/src/video/gem/SDL_gemevents.c
+++ b/src/video/gem/SDL_gemevents.c
@@ -165,7 +165,7 @@ void GEM_PumpEvents(_THIS)
 		/* Key unpressed ? */
 		if (gem_previouskeyboard[i] && !gem_currentkeyboard[i])
 			SDL_PrivateKeyboard(SDL_RELEASED,
-				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, 0));
+				SDL_Atari_TranslateKey(i, &keysym, SDL_FALSE, kstate));
 	}
 
 	SDL_memcpy(gem_previouskeyboard,gem_currentkeyboard,sizeof(gem_previouskeyboard));


### PR DESCRIPTION
Commit 0b2be4c9 wasn't enough, even the released states need to be handled explicitly.

Contributed by @th-otto.