### PR TITLE
atari:video:xbios: mostly Milan/CTPCI fixes

### DIFF
--- a/src/video/ataricommon/SDL_atarimxalloc_c.h
+++ b/src/video/ataricommon/SDL_atarimxalloc_c.h
@@ -30,6 +30,8 @@
 #ifndef _SDL_ATARI_MXALLOC_H_
 #define _SDL_ATARI_MXALLOC_H_
 
+#include "SDL_stdinc.h"
+
 /*--- Functions ---*/
 
 extern void *Atari_SysMalloc(Uint32 size, Uint16 alloc_type);

--- a/src/video/xbios/SDL_xbios.c
+++ b/src/video/xbios/SDL_xbios.c
@@ -475,7 +475,7 @@ static SDL_Surface *XBIOS_SetVideoMode(_THIS, SDL_Surface *current,
 	}
 
 	/* Allocate buffers */
-	if (!(*XBIOS_allocVbuffers)(this, num_buffers, new_screen_size)) {
+	if (!(*XBIOS_allocVbuffers)(this, new_video_mode, num_buffers, new_screen_size)) {
 		XBIOS_FreeBuffers(this);
 		return (NULL);
 	}
@@ -489,20 +489,17 @@ static SDL_Surface *XBIOS_SetVideoMode(_THIS, SDL_Surface *current,
 		return(NULL);
 	}
 
-	XBIOS_current = new_video_mode;
+	/* this is for C2P conversion */
+	XBIOS_pitch = (*XBIOS_getLineWidth)(this, new_video_mode, new_video_mode->width, new_video_mode->depth);
+
 	current->w = width;
 	current->h = height;
 	current->pitch = lineWidth;
-
-	/* this is for C2P conversion */
-	XBIOS_pitch = (*XBIOS_getLineWidth)(this, new_video_mode, new_video_mode->width, new_video_mode->depth);
 
 	if (XBIOS_shadowscreen)
 		current->pixels = XBIOS_shadowscreen;
 	else
 		current->pixels = XBIOS_screens[0];
-
-	XBIOS_fbnum = 0;
 
 #if SDL_VIDEO_OPENGL
 	if (flags & SDL_OPENGL) {
@@ -524,6 +521,9 @@ static SDL_Surface *XBIOS_SetVideoMode(_THIS, SDL_Surface *current,
 
 	(*XBIOS_vsync)(this);
 #endif
+
+	XBIOS_fbnum = 0;
+	XBIOS_current = new_video_mode;
 
 	this->UpdateRects = XBIOS_updRects;
 

--- a/src/video/xbios/SDL_xbios.c
+++ b/src/video/xbios/SDL_xbios.c
@@ -204,12 +204,13 @@ static SDL_VideoDevice *XBIOS_CreateDevice(int devindex)
 
 	device->free = XBIOS_DeleteDevice;
 
+	device->hidden->updRects = XBIOS_UpdateRects;
+
 	/* Setup device specific functions, default to ST for everything */
 	if (Getcookie(C__VDO, &cookie_cvdo) != C_FOUND) {
 		cookie_cvdo = VDO_ST << 16;
 	}
 	SDL_XBIOS_VideoInit_ST(device, cookie_cvdo);
-	device->hidden->updRects = XBIOS_UpdateRects;
 
 	switch (cookie_cvdo>>16) {
 		case VDO_ST:
@@ -292,6 +293,7 @@ void SDL_XBIOS_AddMode(_THIS, int actually_add, const xbiosmode_t *modeinfo)
 	}
 }
 
+/* Called after XBIOS_CreateDevice, and SDL_XBIOS_VideoInit_ST (and its follow-ups) */
 static int XBIOS_VideoInit(_THIS, SDL_PixelFormat *vformat)
 {
 	int i;
@@ -368,7 +370,7 @@ static int XBIOS_VideoInit(_THIS, SDL_PixelFormat *vformat)
 
 	/* Update hardware info */
 	this->info.hw_available = 1;
-	this->info.video_mem = (Uint32) Atari_SysMalloc(-1L, MX_STRAM);
+	this->info.video_mem = (Uint32) Atari_SysMalloc(-1L, MX_STRAM) / 1024;
 
 	/* Init chunky to planar routine */
 	SDL_Atari_C2pConvert = SDL_Atari_C2pConvert8;

--- a/src/video/xbios/SDL_xbios.h
+++ b/src/video/xbios/SDL_xbios.h
@@ -47,16 +47,17 @@ typedef struct
 #define NUM_MODELISTS	4		/* 8, 16, 24, and 32 bits-per-pixel */
 
 struct SDL_PrivateVideoData {
-	long old_video_mode;				/* Old video mode before entering SDL */
-	void *old_video_base;			/* Old pointer to screen buffer */
-	void *old_palette;				/* Old palette */
-	Uint32 old_num_colors;			/* Nb of colors in saved palette */
+	long old_video_mode;		/* Old video mode before entering SDL */
+	void *old_video_base;		/* Old pointer to screen buffer */
+	void *old_palette;		/* Old palette */
+	Uint32 old_num_colors;		/* Nb of colors in saved palette */
 
 	void *screens[2];		/* Pointers to aligned screen buffer */
-	void *screensmem[2];	/* Pointers to screen buffer */
-	void *shadowscreen;		/* Shadow screen for c2p conversion */
+	void *screensmem[2];		/* Pointers to screen buffer */
+	void *shadowscreen;		/* Pointer to aligned shadow screen buffer */
+	void *shadowscreenmem;		/* Pointers to shadow screen buffer */
 	int frame_number;		/* Number of frame for double buffer */
-	int pitch;				/* Destination line width for C2P */
+	int pitch;			/* Destination line width for C2P */
 
 	const xbiosmode_t *current;	/* Current set mode */
 	int SDL_nummodes[NUM_MODELISTS];
@@ -113,8 +114,9 @@ enum {
 #define XBIOS_screens		(this->hidden->screens)
 #define XBIOS_screensmem	(this->hidden->screensmem)
 #define XBIOS_shadowscreen	(this->hidden->shadowscreen)
-#define XBIOS_fbnum			(this->hidden->frame_number)
-#define XBIOS_pitch			(this->hidden->pitch)
+#define XBIOS_shadowscreenmem	(this->hidden->shadowscreenmem)
+#define XBIOS_fbnum		(this->hidden->frame_number)
+#define XBIOS_pitch		(this->hidden->pitch)
 #define XBIOS_current		(this->hidden->current)
 #define XBIOS_recoffset		(this->hidden->recalc_offset)
 
@@ -125,7 +127,7 @@ enum {
 #define XBIOS_saveMode		(this->hidden->saveMode)
 #define XBIOS_setMode		(this->hidden->setMode)
 #define XBIOS_restoreMode	(this->hidden->restoreMode)
-#define XBIOS_vsync			(this->hidden->vsync)
+#define XBIOS_vsync		(this->hidden->vsync)
 #define XBIOS_getScreenFormat	(this->hidden->getScreenFormat)
 #define XBIOS_getLineWidth	(this->hidden->getLineWidth)
 #define XBIOS_swapVbuffers	(this->hidden->swapVbuffers)

--- a/src/video/xbios/SDL_xbios.h
+++ b/src/video/xbios/SDL_xbios.h
@@ -32,6 +32,7 @@
 
 #define XBIOSMODE_DOUBLELINE (1<<0)
 #define XBIOSMODE_C2P (1<<1)
+#define XBIOSMODE_SHADOWCOPY (1<<2)
 
 typedef struct
 {

--- a/src/video/xbios/SDL_xbios.h
+++ b/src/video/xbios/SDL_xbios.h
@@ -57,7 +57,7 @@ struct SDL_PrivateVideoData {
 	int frame_number;		/* Number of frame for double buffer */
 	int pitch;				/* Destination line width for C2P */
 
-	xbiosmode_t *current;	/* Current set mode */
+	const xbiosmode_t *current;	/* Current set mode */
 	int SDL_nummodes[NUM_MODELISTS];
 	SDL_Rect **SDL_modelist[NUM_MODELISTS];
 	xbiosmode_t **SDL_xbiosmode[NUM_MODELISTS];
@@ -69,13 +69,13 @@ struct SDL_PrivateVideoData {
 
 	void (*listModes)(_THIS, int actually_add);	/* List video modes */
 	void (*saveMode)(_THIS, SDL_PixelFormat *vformat);	/* Save mode,palette,vbase change format if needed */
-	void (*setMode)(_THIS, xbiosmode_t *new_video_mode);	/* Set mode */
+	void (*setMode)(_THIS, const xbiosmode_t *new_video_mode);	/* Set mode */
 	void (*restoreMode)(_THIS);	/* Restore system mode */
 	void (*vsync)(_THIS);
 	void (*getScreenFormat)(_THIS, int bpp, Uint32 *rmask, Uint32 *gmask, Uint32 *bmask, Uint32 *amask);	/* Get TrueColor screen format */
-	int (*getLineWidth)(_THIS, xbiosmode_t *new_video_mode, int width, int bpp);	/* Return video mode pitch */
+	int (*getLineWidth)(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp);	/* Return video mode pitch */
 	void (*swapVbuffers)(_THIS);	/* Swap video buffers */
-	int (*allocVbuffers)(_THIS, int num_buffers, int bufsize);	/* Allocate video buffers */
+	int (*allocVbuffers)(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize);	/* Allocate video buffers */
 	void (*freeVbuffers)(_THIS);	/* Free video buffers */
 
 	void (*updRects)(_THIS, int numrects, SDL_Rect *rects);	/* updateRects to use when video ready */

--- a/src/video/xbios/SDL_xbios_centscreen.c
+++ b/src/video/xbios/SDL_xbios_centscreen.c
@@ -35,7 +35,7 @@
 
 static void listModes(_THIS, int actually_add);
 static void saveMode(_THIS, SDL_PixelFormat *vformat);
-static void setMode(_THIS, xbiosmode_t *new_video_mode);
+static void setMode(_THIS, const xbiosmode_t *new_video_mode);
 static void restoreMode(_THIS);
 
 void SDL_XBIOS_VideoInit_Centscreen(_THIS)
@@ -98,7 +98,7 @@ static void saveMode(_THIS, SDL_PixelFormat *vformat)
 	}
 }
 
-static void setMode(_THIS, xbiosmode_t *new_video_mode)
+static void setMode(_THIS, const xbiosmode_t *new_video_mode)
 {
 	centscreen_mode_t newmode, curmode;
 

--- a/src/video/xbios/SDL_xbios_ctpci.c
+++ b/src/video/xbios/SDL_xbios_ctpci.c
@@ -39,9 +39,11 @@
 #include "SDL_xbios.h"
 #include "SDL_xbios_milan.h"
 
-/* use predefined, hardcoded table if CTPCI_USE_TABLE == 1
-   else enumerate all non virtual video modes */
-#define CTPCI_USE_TABLE 1
+/*
+ * Use predefined, hardcoded table if CTPCI_USE_TABLE is defined
+ * else enumerate all non virtual video modes
+ */
+#define CTPCI_USE_TABLE
 
 typedef struct {
 	Uint16 modecode, width, height;
@@ -144,7 +146,7 @@ static void listModes(_THIS, int actually_add)
 
 static void saveMode(_THIS, SDL_PixelFormat *vformat)
 {
-	SCREENINFO si;
+	SCREENINFO si = { 0 };
 
 	/* Read infos about current mode */
 	VsetScreen(-1, &XBIOS_oldvmode, VN_MAGIC, CMD_GETMODE);

--- a/src/video/xbios/SDL_xbios_ctpci.c
+++ b/src/video/xbios/SDL_xbios_ctpci.c
@@ -48,14 +48,12 @@ typedef struct {
 } predefined_mode_t;
 
 static const predefined_mode_t mode_list[]={
-	{0x4260,320,200},
-	{0x4270,320,240},
-	{0x4138,640,480},
-	{0x4160,800,600},
-	{0x4188,1024,768},
-	{0x42c8,1280,800},
-	{0x41e0,1280,1024},
-	{0x4210,1600,1200}
+	/*{VERTFLAG|PAL|VGA,320,240},*/	/* falls back to 640x480 */
+	{PAL|VGA|COL80,640,480},
+	{VESA_600|HORFLAG2|PAL|VGA|COL80,800,600},
+	{VESA_768|HORFLAG2|PAL|VGA|COL80,1024,768},
+	{VERTFLAG2|HORFLAG|PAL|VGA|COL80,1280,960},
+	{VERTFLAG2|VESA_600|HORFLAG2|HORFLAG|PAL|VGA|COL80,1600,1200}
 };
 
 static const Uint8 mode_bpp[]={

--- a/src/video/xbios/SDL_xbios_ctpci.c
+++ b/src/video/xbios/SDL_xbios_ctpci.c
@@ -71,10 +71,10 @@ static SDL_VideoDevice *enum_this;
 
 static void listModes(_THIS, int actually_add);
 static void saveMode(_THIS, SDL_PixelFormat *vformat);
-static void setMode(_THIS, xbiosmode_t *new_video_mode);
+static void setMode(_THIS, const xbiosmode_t *new_video_mode);
 static void restoreMode(_THIS);
-static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp);
-static int allocVbuffers(_THIS, int num_buffers, int bufsize);
+static int getLineWidth(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp);
+static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize);
 static void freeVbuffers(_THIS);
 static void updateRects(_THIS, int numrects, SDL_Rect *rects);
 static int flipHWSurface(_THIS, SDL_Surface *surface);
@@ -172,7 +172,7 @@ static void saveMode(_THIS, SDL_PixelFormat *vformat)
 	}
 }
 
-static void setMode(_THIS, xbiosmode_t *new_video_mode)
+static void setMode(_THIS, const xbiosmode_t *new_video_mode)
 {
 	VsetScreen(-1, XBIOS_screens[0], VN_MAGIC, CMD_SETADR);
 
@@ -194,7 +194,7 @@ static void restoreMode(_THIS)
 	}
 }
 
-static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp)
+static int getLineWidth(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp)
 {
 	SCREENINFO si;
 	int retvalue = width * (((bpp==15) ? 16 : bpp)>>3);
@@ -211,7 +211,7 @@ static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp)
 	return (retvalue);
 }
 
-static int allocVbuffers(_THIS, int num_buffers, int bufsize)
+static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize)
 {
 	int i;
 
@@ -220,7 +220,7 @@ static int allocVbuffers(_THIS, int num_buffers, int bufsize)
 			/* Buffer 0 is current screen */
 			XBIOS_screensmem[i] = XBIOS_oldvbase;
 		} else {
-			VsetScreen(&XBIOS_screensmem[i], XBIOS_current, VN_MAGIC, CMD_ALLOCPAGE);
+			VsetScreen(&XBIOS_screensmem[i], new_video_mode->number, VN_MAGIC, CMD_ALLOCPAGE);
 		}
 
 		if (!XBIOS_screensmem[i]) {

--- a/src/video/xbios/SDL_xbios_f30.c
+++ b/src/video/xbios/SDL_xbios_f30.c
@@ -278,7 +278,7 @@ static int allocVbuffers_SV(_THIS, const xbiosmode_t *new_video_mode, int num_bu
 		SDL_memset(XBIOS_screensmem[i], 0, bufsize);
 
 		/* Align on 256byte boundary and map to Supervidel memory */
-		tmp = ( (Uint32) XBIOS_screensmem[i]+256) & 0xFFFFFF00UL;
+		tmp = ( (Uint32) XBIOS_screensmem[i]+255) & 0xFFFFFF00UL;
 		tmp |= 0xA0000000UL;	/* Map to SV memory */
 		XBIOS_screens[i] = (void *) tmp;
 	}

--- a/src/video/xbios/SDL_xbios_f30.c
+++ b/src/video/xbios/SDL_xbios_f30.c
@@ -31,8 +31,6 @@
 #include <mint/osbind.h>
 #include <mint/falcon.h>
 
-#include "../SDL_sysvideo.h"
-
 #include "../ataricommon/SDL_atarimxalloc_c.h"
 
 #include "SDL_xbios.h"
@@ -41,7 +39,7 @@
 #include "SDL_xbios_centscreen.h"
 
 /* Use shadow buffer on Supervidel */
-/*#define ENABLE_SV_SHADOWBUF 1*/
+/* #define ENABLE_SV_SHADOWBUF */
 
 static const xbiosmode_t rgb_modes[]={
 	{BPS16|COL80|OVERSCAN|VERTFLAG,768,480,16,0},
@@ -71,51 +69,56 @@ static const xbiosmode_t vga_modes[]={
 	{BPS8|VERTFLAG,320,240,8,XBIOSMODE_C2P}
 };
 
+#ifndef ENABLE_SV_SHADOWBUF
+#undef XBIOSMODE_SHADOWCOPY
+#define XBIOSMODE_SHADOWCOPY 0
+#endif
+
 static const xbiosmode_t sv_modes[]={
-	{SVEXT|SVEXT_BASERES(4)|BPS32|COL80|OVERSCAN,2560,1440,32,0},	/* 32-bits */
-	{SVEXT|SVEXT_BASERES(3)|BPS32|COL80|OVERSCAN,1920,1200,32,0},
-	{SVEXT|SVEXT_BASERES(2)|BPS32|COL80|OVERSCAN,1920,1080,32,0},
-	{SVEXT|SVEXT_BASERES(1)|BPS32|COL80|OVERSCAN,1680,1050,32,0},
-	{SVEXT|SVEXT_BASERES(4)|BPS32|COL80,1600,1200,32,0},
-	{SVEXT|SVEXT_BASERES(3)|BPS32|COL80,1280,1024,32,0},
-	{SVEXT|SVEXT_BASERES(0)|BPS32|COL80|OVERSCAN,1280,720,32,0},
-	{SVEXT|SVEXT_BASERES(2)|BPS32|COL80,1024,768,32,0},
-	{SVEXT|SVEXT_BASERES(1)|BPS32|COL80,800,600,32,0},
+	{SVEXT|SVEXT_BASERES(4)|BPS32|COL80|OVERSCAN,2560,1440,32,XBIOSMODE_SHADOWCOPY},	/* 32-bits */
+	{SVEXT|SVEXT_BASERES(3)|BPS32|COL80|OVERSCAN,1920,1200,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(2)|BPS32|COL80|OVERSCAN,1920,1080,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(1)|BPS32|COL80|OVERSCAN,1680,1050,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(4)|BPS32|COL80,1600,1200,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(3)|BPS32|COL80,1280,1024,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(0)|BPS32|COL80|OVERSCAN,1280,720,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(2)|BPS32|COL80,1024,768,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(1)|BPS32|COL80,800,600,32,XBIOSMODE_SHADOWCOPY},
 
-	{SVEXT|SVEXT_BASERES(0)|BPS32|COL80,640,480,32,0},
-	{SVEXT|SVEXT_BASERES(0)|BPS32|COL80|VERTFLAG,640,240,32,0},
-	{SVEXT|SVEXT_BASERES(0)|BPS32,320,480,32,0},
-	{SVEXT|SVEXT_BASERES(0)|BPS32|VERTFLAG,320,240,32,0},
+	{SVEXT|SVEXT_BASERES(0)|BPS32|COL80,640,480,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(0)|BPS32|COL80|VERTFLAG,640,240,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(0)|BPS32,320,480,32,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(0)|BPS32|VERTFLAG,320,240,32,XBIOSMODE_SHADOWCOPY},
 
-	{SVEXT|SVEXT_BASERES(4)|BPS16|COL80|OVERSCAN,2560,1440,16,0},	/* 16-bits */
-	{SVEXT|SVEXT_BASERES(3)|BPS16|COL80|OVERSCAN,1920,1200,16,0},
-	{SVEXT|SVEXT_BASERES(2)|BPS16|COL80|OVERSCAN,1920,1080,16,0},
-	{SVEXT|SVEXT_BASERES(1)|BPS16|COL80|OVERSCAN,1680,1050,16,0},
-	{SVEXT|SVEXT_BASERES(4)|BPS16|COL80,1600,1200,16,0},
-	{SVEXT|SVEXT_BASERES(3)|BPS16|COL80,1280,1024,16,0},
-	{SVEXT|SVEXT_BASERES(0)|BPS16|COL80|OVERSCAN,1280,720,16,0},
-	{SVEXT|SVEXT_BASERES(2)|BPS16|COL80,1024,768,16,0},
-	{SVEXT|SVEXT_BASERES(1)|BPS16|COL80,800,600,16,0},
+	{SVEXT|SVEXT_BASERES(4)|BPS16|COL80|OVERSCAN,2560,1440,16,XBIOSMODE_SHADOWCOPY},	/* 16-bits */
+	{SVEXT|SVEXT_BASERES(3)|BPS16|COL80|OVERSCAN,1920,1200,16,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(2)|BPS16|COL80|OVERSCAN,1920,1080,16,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(1)|BPS16|COL80|OVERSCAN,1680,1050,16,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(4)|BPS16|COL80,1600,1200,16,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(3)|BPS16|COL80,1280,1024,16,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(0)|BPS16|COL80|OVERSCAN,1280,720,16,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(2)|BPS16|COL80,1024,768,16,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(1)|BPS16|COL80,800,600,16,XBIOSMODE_SHADOWCOPY},
 
-	{BPS16|COL80,640,480,16,0},
-	{BPS16|COL80|VERTFLAG,640,240,16,0},
-	{BPS16,320,480,16,0},
-	{BPS16|VERTFLAG,320,240,16,0},
+	{BPS16|COL80,640,480,16,XBIOSMODE_SHADOWCOPY},
+	{BPS16|COL80|VERTFLAG,640,240,16,XBIOSMODE_SHADOWCOPY},
+	{BPS16,320,480,16,XBIOSMODE_SHADOWCOPY},
+	{BPS16|VERTFLAG,320,240,16,XBIOSMODE_SHADOWCOPY},
 
-	{SVEXT|SVEXT_BASERES(4)|BPS8C|COL80|OVERSCAN,2560,1440,8,0},	/* 8-bits chunky */
-	{SVEXT|SVEXT_BASERES(3)|BPS8C|COL80|OVERSCAN,1920,1200,8,0},
-	{SVEXT|SVEXT_BASERES(2)|BPS8C|COL80|OVERSCAN,1920,1080,8,0},
-	{SVEXT|SVEXT_BASERES(1)|BPS8C|COL80|OVERSCAN,1680,1050,8,0},
-	{SVEXT|SVEXT_BASERES(4)|BPS8C|COL80,1600,1200,8,0},
-	{SVEXT|SVEXT_BASERES(3)|BPS8C|COL80,1280,1024,8,0},
-	{SVEXT|SVEXT_BASERES(0)|BPS8C|COL80|OVERSCAN,1280,720,8,0},
-	{SVEXT|SVEXT_BASERES(2)|BPS8C|COL80,1024,768,8,0},
-	{SVEXT|SVEXT_BASERES(1)|BPS8C|COL80,800,600,8,0},
+	{SVEXT|SVEXT_BASERES(4)|BPS8C|COL80|OVERSCAN,2560,1440,8,XBIOSMODE_SHADOWCOPY},	/* 8-bits chunky */
+	{SVEXT|SVEXT_BASERES(3)|BPS8C|COL80|OVERSCAN,1920,1200,8,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(2)|BPS8C|COL80|OVERSCAN,1920,1080,8,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(1)|BPS8C|COL80|OVERSCAN,1680,1050,8,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(4)|BPS8C|COL80,1600,1200,8,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(3)|BPS8C|COL80,1280,1024,8,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(0)|BPS8C|COL80|OVERSCAN,1280,720,8,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(2)|BPS8C|COL80,1024,768,8,XBIOSMODE_SHADOWCOPY},
+	{SVEXT|SVEXT_BASERES(1)|BPS8C|COL80,800,600,8,XBIOSMODE_SHADOWCOPY},
 
-	{BPS8C|COL80,640,480,8,0},
-	{BPS8C|COL80|VERTFLAG,640,240,8,0},
-	{BPS8C,320,480,8,0},
-	{BPS8C|VERTFLAG,320,240,8,0}
+	{BPS8C|COL80,640,480,8,XBIOSMODE_SHADOWCOPY},
+	{BPS8C|COL80|VERTFLAG,640,240,8,XBIOSMODE_SHADOWCOPY},
+	{BPS8C,320,480,8,XBIOSMODE_SHADOWCOPY},
+	{BPS8C|VERTFLAG,320,240,8,XBIOSMODE_SHADOWCOPY}
 };
 
 static int has_supervidel;
@@ -127,10 +130,6 @@ static void restoreMode(_THIS);
 static int setColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors);
 
 static int allocVbuffers_SV(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize);
-#ifdef ENABLE_SV_SHADOWBUF
-static void updateRects_SV(_THIS, int numrects, SDL_Rect *rects);
-static int flipHWSurface_SV(_THIS, SDL_Surface *surface);
-#endif
 
 void SDL_XBIOS_VideoInit_F30(_THIS)
 {
@@ -141,16 +140,16 @@ void SDL_XBIOS_VideoInit_F30(_THIS)
 	XBIOS_setMode = setMode;
 	XBIOS_restoreMode = restoreMode;
 
+	/*
+	 * Must be set before others as it may or may not
+	 * get overwritten by the further inits.
+	 */
 	this->SetColors = setColors;
 
 	/* Supervidel ? */
 	has_supervidel = 0;
 	if (Getcookie(C_SupV, &cookie_dummy) == C_FOUND) {
 		XBIOS_allocVbuffers = allocVbuffers_SV;
-#ifdef ENABLE_SV_SHADOWBUF
-		XBIOS_updRects = updateRects_SV;
-		this->FlipHWSurface = flipHWSurface_SV;
-#endif
 		has_supervidel = 1;
 	} else
 	/* CTPCI ? */
@@ -261,7 +260,7 @@ static int setColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors)
 	}
 	VsetRGB(firstcolor,ncolors,F30_palette);
 
-	return 1;
+	return (1);
 }
 
 static int allocVbuffers_SV(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize)
@@ -284,84 +283,5 @@ static int allocVbuffers_SV(_THIS, const xbiosmode_t *new_video_mode, int num_bu
 		XBIOS_screens[i] = (void *) tmp;
 	}
 
-#ifdef ENABLE_SV_SHADOWBUF
-	/*--- Always use shadow buffer ---*/
-	if (XBIOS_shadowscreen) {
-		Mfree(XBIOS_shadowscreen);
-		XBIOS_shadowscreen=NULL;
-	}
-
-	/* allocate shadow buffer in TT-RAM */
-	XBIOS_shadowscreen = Atari_SysMalloc(bufsize, MX_PREFTTRAM);
-
-	if (XBIOS_shadowscreen == NULL) {
-		SDL_SetError("Can not allocate %d KB for shadow buffer", bufsize>>10);
-		return (0);
-	}
-	SDL_memset(XBIOS_shadowscreen, 0, bufsize);
-#endif
-
 	return (1);
 }
-
-#ifdef ENABLE_SV_SHADOWBUF
-static void updateRects_SV(_THIS, int numrects, SDL_Rect *rects)
-{
-	SDL_Surface *surface;
-	int i;
-
-	surface = this->screen;
-
-	for (i=0;i<numrects;i++) {
-		Uint8 *blockSrcStart, *blockDstStart;
-		int y;
-
-		blockSrcStart = (Uint8 *) surface->pixels;
-		blockSrcStart += surface->pitch*rects[i].y;
-		blockSrcStart += surface->format->BytesPerPixel*rects[i].x;
-
-		blockDstStart = ((Uint8 *) XBIOS_screens[XBIOS_fbnum]) + surface->offset;
-		blockDstStart += XBIOS_pitch*rects[i].y;
-		blockDstStart += surface->format->BytesPerPixel*rects[i].x;
-
-		for(y=0;y<rects[i].h;y++){
-			SDL_memcpy(blockDstStart,blockSrcStart,surface->pitch);
-
-			blockSrcStart += surface->pitch;
-			blockDstStart += XBIOS_pitch;
-		}
-	}
-
-	if ((surface->flags & SDL_DOUBLEBUF) == SDL_DOUBLEBUF) {
-		Setscreen(-1,XBIOS_screens[XBIOS_fbnum],-1);
-		(*XBIOS_vsync)(this);
-
-		XBIOS_fbnum ^= 1;
-	}
-}
-
-static int flipHWSurface_SV(_THIS, SDL_Surface *surface)
-{
-	int i;
-	Uint8 *src, *dst;
-
-	src = surface->pixels;
-	dst = ((Uint8 *) XBIOS_screens[XBIOS_fbnum]) + surface->offset;
-
-	for (i=0; i<surface->h; i++) {
-		SDL_memcpy(dst, src, surface->w * surface->format->BytesPerPixel);
-		src += surface->pitch;
-		dst += XBIOS_pitch;
-
-	}
-
- 	if ((surface->flags & SDL_DOUBLEBUF) == SDL_DOUBLEBUF) {
-		Setscreen(-1,XBIOS_screens[XBIOS_fbnum],-1);
-		(*XBIOS_vsync)(this);
-
-		XBIOS_fbnum ^= 1;
-	}
-
-	return(0);
-}
-#endif

--- a/src/video/xbios/SDL_xbios_f30.c
+++ b/src/video/xbios/SDL_xbios_f30.c
@@ -156,6 +156,7 @@ void SDL_XBIOS_VideoInit_F30(_THIS)
 	/* CTPCI ? */
 	if ((Getcookie(C_CT60, &cookie_dummy) == C_FOUND)
 	    && (Getcookie(C__PCI, &cookie_dummy) == C_FOUND)
+	    /* This check is to differentiate between booting in Videl/Radeon */
 	    && ((unsigned long)Physbase()>=0x01000000UL))
 	{
 		SDL_XBIOS_VideoInit_Ctpci(this);

--- a/src/video/xbios/SDL_xbios_f30.c
+++ b/src/video/xbios/SDL_xbios_f30.c
@@ -122,11 +122,11 @@ static int has_supervidel;
 
 static void listModes(_THIS, int actually_add);
 static void saveMode(_THIS, SDL_PixelFormat *vformat);
-static void setMode(_THIS, xbiosmode_t *new_video_mode);
+static void setMode(_THIS, const xbiosmode_t *new_video_mode);
 static void restoreMode(_THIS);
 static int setColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors);
 
-static int allocVbuffers_SV(_THIS, int num_buffers, int bufsize);
+static int allocVbuffers_SV(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize);
 #ifdef ENABLE_SV_SHADOWBUF
 static void updateRects_SV(_THIS, int numrects, SDL_Rect *rects);
 static int flipHWSurface_SV(_THIS, SDL_Surface *surface);
@@ -223,7 +223,7 @@ static void saveMode(_THIS, SDL_PixelFormat *vformat)
 	}
 }
 
-static void setMode(_THIS, xbiosmode_t *new_video_mode)
+static void setMode(_THIS, const xbiosmode_t *new_video_mode)
 {
 	Setscreen(-1,XBIOS_screens[0],-1);
 
@@ -263,7 +263,7 @@ static int setColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors)
 	return 1;
 }
 
-static int allocVbuffers_SV(_THIS, int num_buffers, int bufsize)
+static int allocVbuffers_SV(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize)
 {
 	int i;
 	Uint32 tmp;

--- a/src/video/xbios/SDL_xbios_milan.c
+++ b/src/video/xbios/SDL_xbios_milan.c
@@ -62,11 +62,11 @@ static SDL_VideoDevice *enum_this;
 
 static void listModes(_THIS, int actually_add);
 static void saveMode(_THIS, SDL_PixelFormat *vformat);
-static void setMode(_THIS, xbiosmode_t *new_video_mode);
+static void setMode(_THIS, const xbiosmode_t *new_video_mode);
 static void restoreMode(_THIS);
-static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp);
+static int getLineWidth(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp);
 static void swapVbuffers(_THIS);
-static int allocVbuffers(_THIS, int num_buffers, int bufsize);
+static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize);
 static void freeVbuffers(_THIS);
 static int setColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors);
 
@@ -157,7 +157,7 @@ static void saveMode(_THIS, SDL_PixelFormat *vformat)
 	}
 }
 
-static void setMode(_THIS, xbiosmode_t *new_video_mode)
+static void setMode(_THIS, const xbiosmode_t *new_video_mode)
 {
 	VsetScreen(-1, XBIOS_screens[0], MI_MAGIC, CMD_SETADR);
 
@@ -185,7 +185,7 @@ static void swapVbuffers(_THIS)
 	VsetScreen(-1, -1, MI_MAGIC, CMD_FLIPPAGE);
 }
 
-static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp)
+static int getLineWidth(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp)
 {
 	SCREENINFO si;
 	int retvalue = width * (((bpp==15) ? 16 : bpp)>>3);
@@ -202,7 +202,7 @@ static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp)
 	return (retvalue);
 }
 
-static int allocVbuffers(_THIS, int num_buffers, int bufsize)
+static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize)
 {
 	int i;
 
@@ -211,7 +211,7 @@ static int allocVbuffers(_THIS, int num_buffers, int bufsize)
 			/* Buffer 0 is current screen */
 			XBIOS_screensmem[i] = XBIOS_oldvbase;
 		} else {
-			VsetScreen(&XBIOS_screensmem[i], XBIOS_current, MI_MAGIC, CMD_ALLOCPAGE);
+			VsetScreen(&XBIOS_screensmem[i], new_video_mode->number, MI_MAGIC, CMD_ALLOCPAGE);
 		}
 
 		if (!XBIOS_screensmem[i]) {

--- a/src/video/xbios/SDL_xbios_milan.c
+++ b/src/video/xbios/SDL_xbios_milan.c
@@ -183,7 +183,6 @@ static void restoreMode(_THIS)
 
 static void swapVbuffers(_THIS)
 {
-	/*VsetScreen(-1, XBIOS_screens[XBIOS_fbnum], MI_MAGIC, CMD_SETADR);*/
 	VsetScreen(-1, -1, MI_MAGIC, CMD_FLIPPAGE);
 }
 

--- a/src/video/xbios/SDL_xbios_milan.h
+++ b/src/video/xbios/SDL_xbios_milan.h
@@ -155,30 +155,34 @@ typedef struct screeninfo {
 	unsigned long	pagemem;	/* needed memory for one page */ 
 	unsigned long	max_x;		/* max. possible width */ 
 	unsigned long	max_y;		/* max. possible heigth */ 
+
+	/* CTPCI only? */
+	unsigned long refresh;		/* refresh in Hz */
+	unsigned long pixclock;		/* pixel clock in pS */
 } SCREENINFO; 
 
 typedef struct _scrfillblk {
-	long size;	/* size of structure           */
-	long blk_status;/* status bits of blk          */
-	long blk_op;	/* mode operation              */
-	long blk_color;	/* background fill color       */
-	long blk_x;	/* x pos in total screen       */
-	long blk_y;	/* y pos in total screen       */
-	long blk_w;	/* width                       */
-	long blk_h;	/* height                      */
+	long size;		/* size of structure           */
+	long blk_status;	/* status bits of blk          */
+	long blk_op;		/* mode operation              */
+	long blk_color;		/* background fill color       */
+	long blk_x;		/* x pos in total screen       */
+	long blk_y;		/* y pos in total screen       */
+	long blk_w;		/* width                       */
+	long blk_h;		/* height                      */
 	long blk_unused;
 } SCRFILLMEMBLK;
              
 typedef struct _scrcopyblk {
-	long size;	/* size of structure            */
-	long blk_status;/* status bits of blk           */
-	long blk_src_x;	/* x pos source in total screen */
-	long blk_src_y;	/* y pos source in total screen */
-	long blk_dst_x;	/* x pos dest in total screen   */
-	long blk_dst_y;	/* y pos dest in total screen   */
-	long blk_w;	/* width                        */
-	long blk_h;	/* height                       */
-	long blk_op;	/* block operation */
+	long size;		/* size of structure            */
+	long blk_status;	/* status bits of blk           */
+	long blk_src_x;		/* x pos source in total screen */
+	long blk_src_y;		/* y pos source in total screen */
+	long blk_dst_x;		/* x pos dest in total screen   */
+	long blk_dst_y;		/* y pos dest in total screen   */
+	long blk_w;		/* width                        */
+	long blk_h;		/* height                       */
+	long blk_op;		/* block operation		*/
 } SCRCOPYMEMBLK;
 
 typedef struct _scrtextureblk {
@@ -208,5 +212,15 @@ typedef struct _scrlineblk {
 	long blk_op;		/* mode operation               */
 	long blk_pattern;	/* pattern (-1: solid line)     */
 } SCRLINEMEMBLK;
+
+typedef struct _scrclipblk {
+	long size;		/* size of structure            */
+	long blk_status;	/* status bits of blk           */
+	long blk_clip_on;	/* clipping flag 1:on, 0:off    */
+	long blk_x;		/* x pos in total screen        */
+	long blk_y;		/* y pos in in total screen     */
+	long blk_w;		/* width                        */
+	long blk_h;		/* height                       */
+} SCRCLIPMEMBLK;
 
 #endif /* _SDL_xbios_milan_h */

--- a/src/video/xbios/SDL_xbios_milan.h
+++ b/src/video/xbios/SDL_xbios_milan.h
@@ -39,6 +39,19 @@
 #define MI_MAGIC	0x4D49	/* Milan */
 #define VN_MAGIC	0x564E	/* CTPCI */
 
+/* Vsetscreen() modecode extended flags */
+
+#define HORFLAG		0x200	/* double width */
+#define HORFLAG2	0x400	/* width increased */
+#define VESA_600	0x800	/* SVGA 600 lines */
+#define VESA_768	0x1000	/* SVGA 768 lines */
+#define VERTFLAG2	0x2000	/* double height */
+#define DEVID		0x4000	/* bits 11-3 used for devID */
+#define VIRTUAL_SCREEN	0x8000	/* width * 2 and height * 2, 2048 x 2048 max */
+
+#define GET_DEVID(x) (((x) & DEVID) ? (((x) & 0x3FF8) >> 3) : -1)
+#define SET_DEVID(x) ((((x) << 3) & 0x3FF8) | DEVID)
+
 enum {
 	/* Milan/CTPCI */
 	CMD_GETMODE=0,

--- a/src/video/xbios/SDL_xbios_nova.c
+++ b/src/video/xbios/SDL_xbios_nova.c
@@ -58,13 +58,13 @@ static void XBIOS_DeleteDevice_NOVA(_THIS);
 
 static void listModes(_THIS, int actually_add);
 static void saveMode(_THIS, SDL_PixelFormat *vformat);
-static void setMode(_THIS, xbiosmode_t *new_video_mode);
+static void setMode(_THIS, const xbiosmode_t *new_video_mode);
 static void restoreMode(_THIS);
 static void vsync_NOVA(_THIS);
 static void getScreenFormat(_THIS, int bpp, Uint32 *rmask, Uint32 *gmask, Uint32 *bmask, Uint32 *amask);
-static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp);
+static int getLineWidth(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp);
 static void swapVbuffers(_THIS);
-static int allocVbuffers(_THIS, int num_buffers, int bufsize);
+static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize);
 static void freeVbuffers(_THIS);
 static int setColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors);
 
@@ -170,7 +170,7 @@ static void saveMode(_THIS, SDL_PixelFormat *vformat)
 	NOVA_xcb->blnk_time = 0;
 }
 
-static void setMode(_THIS, xbiosmode_t *new_video_mode)
+static void setMode(_THIS, const xbiosmode_t *new_video_mode)
 {
 	NOVA_SetMode(this, new_video_mode->number);
 }
@@ -234,7 +234,7 @@ static void getScreenFormat(_THIS, int bpp, Uint32 *rmask, Uint32 *gmask, Uint32
 	}
 }
 
-static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp)
+static int getLineWidth(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp)
 {
 	return (NOVA_modes[new_video_mode->number].pitch);
 }
@@ -244,7 +244,7 @@ static void swapVbuffers(_THIS)
 	NOVA_SetScreen(this, XBIOS_screens[XBIOS_fbnum]);
 }
 
-static int allocVbuffers(_THIS, int num_buffers, int bufsize)
+static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize)
 {
 	XBIOS_screens[0] = NOVA_xcb->base;
 	if (num_buffers>1) {

--- a/src/video/xbios/SDL_xbios_sb3.c
+++ b/src/video/xbios/SDL_xbios_sb3.c
@@ -52,7 +52,7 @@ const int SDL_XBIOS_scpn_planes_device[]={
 /*--- Functions ---*/
 
 static void listModes(_THIS, int actually_add);
-static void setMode(_THIS, xbiosmode_t *new_video_mode);
+static void setMode(_THIS, const xbiosmode_t *new_video_mode);
 static void restoreMode(_THIS);
 
 int SDL_XBIOS_SB3Usable(scpn_cookie_t *cookie_scpn)
@@ -100,7 +100,7 @@ static void listModes(_THIS, int actually_add)
 	}
 }
 
-static void setMode(_THIS, xbiosmode_t *new_video_mode)
+static void setMode(_THIS, const xbiosmode_t *new_video_mode)
 {
 	/* SB3 do not allow changing video mode */
 	Setscreen(-1,XBIOS_screens[0],-1);

--- a/src/video/xbios/SDL_xbios_st.c
+++ b/src/video/xbios/SDL_xbios_st.c
@@ -42,14 +42,14 @@ static const xbiosmode_t stmodes[]={
 
 static void listModes(_THIS, int actually_add);
 static void saveMode(_THIS, SDL_PixelFormat *vformat);
-static void setMode_ST(_THIS, xbiosmode_t *new_video_mode);
-static void setMode_STE(_THIS, xbiosmode_t *new_video_mode);
+static void setMode_ST(_THIS, const xbiosmode_t *new_video_mode);
+static void setMode_STE(_THIS, const xbiosmode_t *new_video_mode);
 static void restoreMode(_THIS);
 static void vsync_ST(_THIS);
 static void getScreenFormat(_THIS, int bpp, Uint32 *rmask, Uint32 *gmask, Uint32 *bmask, Uint32 *amask);
-static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp);
+static int getLineWidth(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp);
 static void swapVbuffers(_THIS);
-static int allocVbuffers(_THIS, int num_buffers, int bufsize);
+static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize);
 static void freeVbuffers(_THIS);
 static int setColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors);
 
@@ -104,7 +104,7 @@ static void saveMode(_THIS, SDL_PixelFormat *vformat)
 	}
 }
 
-static void setMode_ST(_THIS, xbiosmode_t *new_video_mode)
+static void setMode_ST(_THIS, const xbiosmode_t *new_video_mode)
 {
 	int i;
 
@@ -119,7 +119,7 @@ static void setMode_ST(_THIS, xbiosmode_t *new_video_mode)
 	Setpalette(TT_palette);
 }
 
-static void setMode_STE(_THIS, xbiosmode_t *new_video_mode)
+static void setMode_STE(_THIS, const xbiosmode_t *new_video_mode)
 {
 	int i;
 
@@ -156,7 +156,7 @@ static void getScreenFormat(_THIS, int bpp, Uint32 *rmask, Uint32 *gmask, Uint32
 	*rmask = *gmask = *bmask = *amask = 0;
 }
 
-static int getLineWidth(_THIS, xbiosmode_t *new_video_mode, int width, int bpp)
+static int getLineWidth(_THIS, const xbiosmode_t *new_video_mode, int width, int bpp)
 {
 	if (bpp==4) {
 		return (width >> 1);
@@ -170,7 +170,7 @@ static void swapVbuffers(_THIS)
 	Setscreen(-1,XBIOS_screens[XBIOS_fbnum],-1);
 }
 
-static int allocVbuffers(_THIS, int num_buffers, int bufsize)
+static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffers, int bufsize)
 {
 	int i;
 

--- a/src/video/xbios/SDL_xbios_st.c
+++ b/src/video/xbios/SDL_xbios_st.c
@@ -37,7 +37,7 @@
 #include "SDL_xbios.h"
 
 static const xbiosmode_t stmodes[]={
-	{ST_LOW>>8,320,200,4, XBIOSMODE_C2P}
+	{ST_LOW>>8,320,200,4,XBIOSMODE_C2P}
 };
 
 static void listModes(_THIS, int actually_add);

--- a/src/video/xbios/SDL_xbios_st.c
+++ b/src/video/xbios/SDL_xbios_st.c
@@ -183,7 +183,7 @@ static int allocVbuffers(_THIS, const xbiosmode_t *new_video_mode, int num_buffe
 		}
 		SDL_memset(XBIOS_screensmem[i], 0, bufsize);
 
-		XBIOS_screens[i]=(void *) (( (long) XBIOS_screensmem[i]+256) & 0xFFFFFF00UL);
+		XBIOS_screens[i]=(void *) (( (long) XBIOS_screensmem[i]+255) & 0xFFFFFF00UL);
 	}
 
 	return (1);
@@ -196,8 +196,9 @@ static void freeVbuffers(_THIS)
 	for (i=0;i<2;i++) {
 		if (XBIOS_screensmem[i]) {
 			Mfree(XBIOS_screensmem[i]);
+			XBIOS_screensmem[i]=NULL;
 		}
-		XBIOS_screensmem[i]=NULL;
+		XBIOS_screens[i]=NULL;
 	}
 }
 

--- a/src/video/xbios/SDL_xbios_tt.c
+++ b/src/video/xbios/SDL_xbios_tt.c
@@ -36,8 +36,8 @@
 #include "SDL_xbios_nova.h"
 
 static const xbiosmode_t ttmodes[]={
-	{TT_LOW,320,480,8, XBIOSMODE_C2P},
-	{TT_LOW,320,240,8, XBIOSMODE_C2P|XBIOSMODE_DOUBLELINE}
+	{TT_LOW,320,480,8,XBIOSMODE_C2P},
+	{TT_LOW,320,240,8,XBIOSMODE_C2P|XBIOSMODE_DOUBLELINE}
 };
 
 static void listModes(_THIS, int actually_add);

--- a/src/video/xbios/SDL_xbios_tt.c
+++ b/src/video/xbios/SDL_xbios_tt.c
@@ -42,7 +42,7 @@ static const xbiosmode_t ttmodes[]={
 
 static void listModes(_THIS, int actually_add);
 static void saveMode(_THIS, SDL_PixelFormat *vformat);
-static void setMode(_THIS, xbiosmode_t *new_video_mode);
+static void setMode(_THIS, const xbiosmode_t *new_video_mode);
 static void restoreMode(_THIS);
 static int setColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors);
 
@@ -99,7 +99,7 @@ static void saveMode(_THIS, SDL_PixelFormat *vformat)
 	}
 }
 
-static void setMode(_THIS, xbiosmode_t *new_video_mode)
+static void setMode(_THIS, const xbiosmode_t *new_video_mode)
 {
 	Setscreen(-1,XBIOS_screens[0],-1);
 


### PR DESCRIPTION
This is a set of commits which fix various crashes and incorrect behaviour on my Atari Falcon + CT60 + CTPCI graphics card. As a result, one can now safely use SDL_VIDEODRIVER=xbios and everything works. I believe it had never worked before.

I have also cleaned up many parts of the code.
