### PR TITLE
Quartz: Don't enforce 32 bpp in older OSX releases (issue #888)

### DIFF
--- a/src/video/quartz/SDL_QuartzVideo.m
+++ b/src/video/quartz/SDL_QuartzVideo.m
@@ -285,13 +285,10 @@ static void QZ_GetModeInfo(_THIS, const void *_mode, Uint32 *w, Uint32 *h, Uint3
         CFNumberGetValue (
             CFDictionaryGetValue (vidmode, kCGDisplayHeight),
             kCFNumberSInt32Type, h);
+
+        /* on older OS X, accept all bpp */
     }
 #endif
-
-    /* we only care about the 32-bit modes... */
-    if (*bpp != 32) {
-        *bpp = 0;
-    }
 }
 
 static int QZ_VideoInit (_THIS, SDL_PixelFormat *video_format)


### PR DESCRIPTION
See issue #888.

Commit 991bbb91c8cff091c7c1aee216e02949080756b6 added a QZ_GetModeInfo() restriction, rejecting displays < 32 bpp. It seems that SDL 1.2.15 was the first SDL 1.2 adding this restriction.

But it's trivial on OSX 10.4 to have a monitor set to only "Thousands of colors" in the system preferences (especially when one uses Classic Mode or runs games requiring a lower bit depth).  Moreover, it appears that it worked just fine, at least on OSX PPC 10.4/10.5.

The change made some OSX PPC apps (still maintained there to this day, using SDL 1.2), such as DOSBox 0.74-3-3 or ScummVM 2.9.0, fail right after SDL_Init() with a fatal "Unsupported display mode" initialization error.  Earlier releases using SDL < 1.2.15 worked fine for people using a lower bit depth on older OSX, though.

So the original intent may have been to restrict to 32-bpp output for "newer" OSX releases only. Let's go for this behavior, and see if anyone reports any issue with that.