### PR TITLE
Convert RISC OS assembler code to use GAS syntax, and make it optional

### DIFF
--- a/configure
+++ b/configure
@@ -22484,7 +22484,9 @@ case "$host" in
             $as_echo "#define SDL_VIDEO_DRIVER_RISCOS 1" >>confdefs.h
 
             SOURCES="$SOURCES $srcdir/src/video/riscos/*.c"
-            SOURCES="$SOURCES $srcdir/src/video/riscos/*.S"
+            if test x$enable_assembly = xyes; then
+                SOURCES="$SOURCES $srcdir/src/video/riscos/*.S"
+            fi
             have_video=yes
         fi
         # Set up files for the joystick library

--- a/configure.ac
+++ b/configure.ac
@@ -2947,7 +2947,9 @@ case "$host" in
         if test x$enable_video = xyes; then
             AC_DEFINE(SDL_VIDEO_DRIVER_RISCOS)
             SOURCES="$SOURCES $srcdir/src/video/riscos/*.c"
-            SOURCES="$SOURCES $srcdir/src/video/riscos/*.S"
+            if test x$enable_assembly = xyes; then
+                SOURCES="$SOURCES $srcdir/src/video/riscos/*.S"
+            fi
             have_video=yes
         fi
         # Set up files for the joystick library

--- a/src/video/riscos/SDL_riscosASM.S
+++ b/src/video/riscos/SDL_riscosASM.S
@@ -1,75 +1,79 @@
-;
-;    SDL - Simple DirectMedia Layer
-;    Copyright (C) 1997-2012 Sam Lantinga
-;
-;    This library is free software; you can redistribute it and/or
-;    modify it under the terms of the GNU Library General Public
-;    License as published by the Free Software Foundation; either
-;    version 2 of the License, or (at your option) any later version.
-;
-;    This library is distributed in the hope that it will be useful,
-;    but WITHOUT ANY WARRANTY; without even the implied warranty of
-;    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;    Library General Public License for more details.
-;
-;    You should have received a copy of the GNU Library General Public
-;    License along with this library; if not, write to the Free
-;    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-;
-;    Sam Lantinga
-;    slouken@libsdl.org
-;
-; Assembler routines for RISC OS display
-;
+@
+@    SDL - Simple DirectMedia Layer
+@    Copyright (C) 1997-2012 Sam Lantinga
+@
+@    This library is free software; you can redistribute it and/or
+@    modify it under the terms of the GNU Library General Public
+@    License as published by the Free Software Foundation; either
+@    version 2 of the License, or (at your option) any later version.
+@
+@    This library is distributed in the hope that it will be useful,
+@    but WITHOUT ANY WARRANTY; without even the implied warranty of
+@    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+@    Library General Public License for more details.
+@
+@    You should have received a copy of the GNU Library General Public
+@    License along with this library; if not, write to the Free
+@    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+@
+@    Sam Lantinga
+@    slouken@libsdl.org
+@
+@ Assembler routines for RISC OS display
+@
 
-	AREA |C$$CODE|
+@	AREA |C$$CODE|
 
-	EXPORT |RISCOS_Put32|
+@	EXPORT |RISCOS_Put32|
+	.global RISCOS_Put32
 
-; Display 32bpp to 32bpp, 1:1
-;
-; Code provided by Adrain Lees
-;
-; entry a1 -> destination
-;       a2 =  dest width in pixels
-;       a3 =  dest line length in bytes
-;       a4 =  dest height in scanlines
-;       arg5 -> source
-;       arg6 =  byte offset from end of source line to start of next
+@ Display 32bpp to 32bpp, 1:1
+@
+@ Code provided by Adrain Lees
+@
+@ entry a1 -> destination
+@       a2 =  dest width in pixels
+@       a3 =  dest line length in bytes
+@       a4 =  dest height in scanlines
+@       arg5 -> source
+@       arg6 =  byte offset from end of source line to start of next
 
-Arg5    *       10*4
-Arg6    *       Arg5+4
+@Arg5    *       10*4
+@Arg6    *       Arg5+4
 
-RISCOS_Put32    ROUT
+.set Arg5, 10*4
+.set Arg6, Arg5+4
+
+RISCOS_Put32:
                 STMFD   sp!,{a2,v1-v6,sl,fp,lr}
                 LDR     ip,[sp,#Arg5]
                 MOV     lr,a1
                 B       ucp64lp
 
-00              ;tail strip of 1-15 pixels
+L00:            @tail strip of 1-15 pixels
 
                 LDR     v1,[ip],#4
-01              SUBS    a2,a2,#1
+L01:            SUBS    a2,a2,#1
                 STR     v1,[lr],#4
                 LDRHI   v1,[ip],#4
-                BHI     %01
-                B       %02
+                BHI     L01
+                B       L02
 
-ucp64end        ADDS    a2,a2,#16
-                BNE     %00
+ucp64end:       ADDS    a2,a2,#16
+                BNE     L00
 
-02              SUBS    a4,a4,#1                ;height--
+L02:            SUBS    a4,a4,#1                @height--
                 LDRHI   v1,[sp,#Arg6]
-                LDRHI   a2,[sp]                 ;reload width
-                BLS     %03
+                LDRHI   a2,[sp]                 @reload width
+                BLS     L03
 
-                ;move to start of next scanline
+                @move to start of next scanline
 
                 ADD     lr,a1,a3
                 ADD     a1,a1,a3
                 ADD     ip,ip,v1
 
-ucp64lp         SUBS    a2,a2,#16
+ucp64lp:        SUBS    a2,a2,#16
                 BLO     ucp64end
 
                 PLD     [ip,#64]
@@ -112,5 +116,5 @@ ucp64lp         SUBS    a2,a2,#16
 
                 B       ucp64lp
 
-03              LDMFD   sp!,{a2,v1-v6,sl,fp,pc}
+L03:            LDMFD   sp!,{a2,v1-v6,sl,fp,pc}
 

--- a/src/video/riscos/SDL_riscosFullScreenVideo.c
+++ b/src/video/riscos/SDL_riscosFullScreenVideo.c
@@ -66,9 +66,11 @@ static void FULLSCREEN_SetWMCaption(_THIS, const char *title, const char *icon);
 /* UpdateRects variants */
 static void FULLSCREEN_UpdateRects(_THIS, int numrects, SDL_Rect *rects);
 static void FULLSCREEN_UpdateRectsMemCpy(_THIS, int numrects, SDL_Rect *rects);
+#ifdef SDL_ASSEMBLY_ROUTINES
 static void FULLSCREEN_UpdateRects8bpp(_THIS, int numrects, SDL_Rect *rects);
 static void FULLSCREEN_UpdateRects16bpp(_THIS, int numrects, SDL_Rect *rects);
 static void FULLSCREEN_UpdateRects32bpp(_THIS, int numrects, SDL_Rect *rects);
+#endif
 static void FULLSCREEN_UpdateRectsOS(_THIS, int numrects, SDL_Rect *rects);
 
 /* Local helper functions */
@@ -213,6 +215,7 @@ void FULLSCREEN_SetDeviceMode(_THIS)
             case 2: /* ARM code full word copy */
                switch(this->screen->format->BytesPerPixel)
                {
+#ifdef SDL_ASSEMBLY_ROUTINES
                   case 1: /* 8bpp modes */
                	   this->UpdateRects = FULLSCREEN_UpdateRects8bpp;
                      break;
@@ -222,7 +225,7 @@ void FULLSCREEN_SetDeviceMode(_THIS)
                   case 4: /* 32 bpp modes */
                	   this->UpdateRects = FULLSCREEN_UpdateRects32bpp;
                      break;
-
+#endif
                   default: /* Just default to the memcpy routine */
                	   this->UpdateRects = FULLSCREEN_UpdateRectsMemCpy;
                      break;
@@ -388,6 +391,8 @@ static void FULLSCREEN_UpdateRectsMemCpy(_THIS, int numrects, SDL_Rect *rects)
       }
 }
 
+#ifdef SDL_ASSEMBLY_ROUTINES
+
 /* Use optimized assembler memory copy. Deliberately copies extra columns if
    necessary to ensure the rectangle is word aligned. */
 static void FULLSCREEN_UpdateRects8bpp(_THIS, int numrects, SDL_Rect *rects)
@@ -465,6 +470,8 @@ static void FULLSCREEN_UpdateRects32bpp(_THIS, int numrects, SDL_Rect *rects)
       rects++;
    }
 }
+
+#endif
 
 /* Use operating system sprite plots. Currently this is much slower than the
    other variants however accelerated sprite plotting can be seen on the horizon

--- a/src/video/riscos/SDL_riscosvideo.h
+++ b/src/video/riscos/SDL_riscosvideo.h
@@ -105,8 +105,10 @@ extern void FULLSCREEN_BuildModeList(_THIS);
 extern SDL_Surface *FULLSCREEN_SetVideoMode(_THIS, SDL_Surface *current, int width, int height, int bpp, Uint32 flags);
 extern int FULLSCREEN_ToggleFromWimp(_THIS);
 
+#ifdef SDL_ASSEMBLY_ROUTINES
 /* SDL_riscosASM.S */
 extern void RISCOS_Put32(void *to, int pixels, int pitch, int rows, void *from, int src_skip_bytes); /* Fast assembler copy */
+#endif
 
 /* SDL_wimppoll.c */
 extern int mouseInWindow; /* Mouse is in WIMP window */


### PR DESCRIPTION
The main part of this PR comes from a [GCCSDK autobuilder patch](https://github.com/riscos-dot-info/gccsdk/blob/master/autobuilder/libraries/sdl/libsdl1.2debian/video.p.elf) dating back to 2008, which is required for building with GCC 4 or later. It has been adapted to allow disabling the assembler so that it can still be built with GCC 3, although I'm not able to test it there.