### PR TITLE
Patch from StepMania 3.9 (2006-09-01) to add `SDL_SetRefreshRate`.

### DIFF
--- a/include/SDL_video.h
+++ b/include/SDL_video.h
@@ -942,7 +942,15 @@ extern DECLSPEC SDL_GrabMode SDLCALL SDL_WM_GrabInput(SDL_GrabMode mode);
 /** @internal Not in public API at the moment - do not use! */
 extern DECLSPEC int SDLCALL SDL_SoftStretch(SDL_Surface *src, SDL_Rect *srcrect,
                                     SDL_Surface *dst, SDL_Rect *dstrect);
-                    
+
+#define SDL_REFRESH_DEFAULT 0
+
+/*
+ * Set the desired refresh rate, in Hz.  This takes effect on the next
+ * video mode change.
+ */
+extern DECLSPEC void SDLCALL SDL_SetRefreshRate(int rate);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -422,6 +422,8 @@ extern VideoBootStrap DUMMY_bootstrap;
 /* This is the current video device */
 extern SDL_VideoDevice *current_video;
 
+extern int refresh_rate;
+
 #define SDL_VideoSurface	(current_video->screen)
 #define SDL_ShadowSurface	(current_video->shadow)
 #define SDL_PublicSurface	(current_video->visible)

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -139,6 +139,13 @@ static VideoBootStrap *bootstrap[] = {
 
 SDL_VideoDevice *current_video = NULL;
 
+int refresh_rate = SDL_REFRESH_DEFAULT;
+
+void SDL_SetRefreshRate(int rate)
+{
+	refresh_rate = rate;
+}
+
 /* Various local functions */
 int SDL_VideoInit(const char *driver_name, Uint32 flags);
 void SDL_VideoQuit(void);

--- a/src/video/wincommon/SDL_sysevents.c
+++ b/src/video/wincommon/SDL_sysevents.c
@@ -614,6 +614,8 @@ LRESULT CALLBACK WinMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			if ( SDL_PublicSurface && 
 				(SDL_PublicSurface->flags & SDL_RESIZABLE) ) {
 				SDL_PrivateResize(w, h);
+				SDL_VideoSurface->w = w;
+				SDL_VideoSurface->h = h;
 			}
 		}
 		break;

--- a/src/video/windib/SDL_dibvideo.c
+++ b/src/video/windib/SDL_dibvideo.c
@@ -760,7 +760,11 @@ SDL_Surface *DIB_SetVideoMode(_THIS, SDL_Surface *current,
 		settings.dmPelsWidth = width;
 		settings.dmPelsHeight = height;
 		settings.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT | DM_BITSPERPEL;
-		if ( width <= (int)SDL_desktop_mode.dmPelsWidth &&
+		if ( refresh_rate > 0 ) {
+			settings.dmDisplayFrequency = refresh_rate;
+			settings.dmFields |= DM_DISPLAYFREQUENCY;
+		}
+		else if ( width <= (int)SDL_desktop_mode.dmPelsWidth &&
 		     height <= (int)SDL_desktop_mode.dmPelsHeight ) {
 			settings.dmDisplayFrequency = SDL_desktop_mode.dmDisplayFrequency;
 			settings.dmFields |= DM_DISPLAYFREQUENCY;


### PR DESCRIPTION
Hi SDL 1.2 maintainers,

I'm submitting this patch upstream because I believe this is where it truly belongs.

I don't know who originally authored it, nor when it was actually written. I discovered it in a fork of SDL 1.2.6 dating back nearly 20 years. At the time, I recall the SDL team choosing not to adopt this direction and rejecting the patch. Since then, I've maintained it privately for the past 15 years.

This patch has been used in various StepMania versions and introduces a new public API method: `SDL_SetRefreshRate`. It allows arcade machine operators to specify a target frame rate, an important feature in that context.

The time has come for me to part ways with this code. I’m submitting it here not with expectation, but with respect. If this is its final resting place, so be it. I trust your judgment and I will honor whatever decision you make.

Thanks for your time and consideration.