### PR TITLE
Makefile.dc: update install paths and streamline build process; 60hz.…

### DIFF
--- a/Makefile.dc
+++ b/Makefile.dc
@@ -102,7 +102,7 @@ OBJS := $(SRCS:.c=.o)
 
 # ------------------------------ Install locations ------------------------------
 INSTALL_LIB_DIR     := $(KOS_BASE)/addons/lib/$(KOS_ARCH)
-INSTALL_INCLUDE_DIR := $(KOS_BASE)/addons/include/$(KOS_ARCH)/SDL
+INSTALL_INCLUDE_DIR := $(KOS_BASE)/addons/include/SDL
 INSTALL_LIB         := $(INSTALL_LIB_DIR)/$(TARGET)
 
 # ------------------------------ Phony targets ------------------------------
@@ -123,20 +123,20 @@ $(OBJS): include/SDL_config.h include/SDL_config_dreamcast.h
 %.o: %.c
 	$(CC) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
-# Single main target: build + install archive to addons/lib
-$(TARGET): copy_headers $(OBJS)
-	@mkdir -p $(INSTALL_LIB_DIR)
-	@rm -f $(INSTALL_LIB)
-	$(AR) $(ARFLAGS) $(INSTALL_LIB) $(OBJS)
-	@touch $@  # local stamp
+# Single main target: build local archive only
+$(TARGET): $(OBJS)
+	@rm -f $@
+	$(AR) $(ARFLAGS) $@ $(OBJS)
 
 # Copy public headers into addons include dir
 copy_headers: include/SDL_config.h
 	@mkdir -p $(INSTALL_INCLUDE_DIR)
 	@cp -R include/*.h $(INSTALL_INCLUDE_DIR)/
 
-# Convenience
-install: $(TARGET)
+# Copy archive and public headers into KOS addons
+install: $(TARGET) copy_headers
+	@mkdir -p $(INSTALL_LIB_DIR)
+	@cp -f $(TARGET) $(INSTALL_LIB)
 
 # Remove installed files under addons (does NOT touch repo files)
 uninstall:

--- a/src/video/dc/60hz.h
+++ b/src/video/dc/60hz.h
@@ -755,7 +755,7 @@ static void __ask_60hz_fade16(unsigned short n)
 			b=0;
 		buff[i+j*640]=((r<<rs) | (g<<gs) | (b<<bs));
 	}
-	timer_spin_sleep(10);
+	thd_sleep(10);
 }
 
 static int __ask_60hz_wait(void)
@@ -781,7 +781,7 @@ static int __ask_60hz_wait(void)
 		for(i=0;i<500;i++)
 		{
 			if (cond->buttons & CONT_Y) return !sdl_dc_default_60hz;
-			timer_spin_sleep(10);
+			thd_sleep(10);
 		}
 	}
 	


### PR DESCRIPTION
Makefile.dc, I had to remove the default SDL include/lib install location automatically, since kos-ports installs them already.

and had to replace timer_spin_sleep with thd_sleep as the function had been deprecated in the 60hz.h file.