### PR TITLE
Fix SDL_GetRGBA alpha channel on palette surfaces

### DIFF
--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -424,7 +424,11 @@ void SDL_GetRGBA(Uint32 pixel, const SDL_PixelFormat * const fmt,
 		*r = fmt->palette->colors[pixel].r;
 		*g = fmt->palette->colors[pixel].g;
 		*b = fmt->palette->colors[pixel].b;
+#ifdef ENABLE_PALETTE_ALPHA
+		*a = fmt->palette->colors[pixel].unused;
+#else
 		*a = SDL_ALPHA_OPAQUE;
+#endif
 	}
 }
 


### PR DESCRIPTION
SDL_pixels.c supports palettes with alpha-channel when compiled with `ENABLE_PALETTE_ALPHA` defined - however this wasn't checked in SDL_GetRGBA, causing the function to always return fully-opaque instead of the alpha value from the palette.